### PR TITLE
Replace UIViewRepresentable with native SwiftUI where possible

### DIFF
--- a/App/Pages/HIButtonsView.swift
+++ b/App/Pages/HIButtonsView.swift
@@ -7,29 +7,6 @@
 
 import SwiftUI
 
-struct HIDefaultButton: View, UIViewRepresentable {
-	typealias UIViewType = UIButton
-	let view = UIButton(type:.system)
-	var title = ""
-	var action = {}
-	
-	func makeUIView(context: Context) -> UIViewType {
-		view.role = .primary
-		return view
-	}
-	
-	func updateUIView(_ uiView: UIViewType, context: Context) {
-		view.setTitle(title, for: .normal)
-		view.addAction(UIAction(handler: { _ in
-			self.action()
-		}), for: .touchUpInside)
-		
-		view.setContentHuggingPriority(.required, for: .horizontal) // << here !!
-		view.setContentHuggingPriority(.required, for: .vertical)
-	}
-}
-
-
 struct HIButtonsView: View {
 	var body: some View {
 		VStack(alignment:.leading) {
@@ -37,17 +14,14 @@ struct HIButtonsView: View {
 				.bold()
 			
 			HStack {
-				Button("Cancel") {
-					
-				}
-				
-				HIDefaultButton(title:"OK", action:{})
-				
+				Button("Cancel") {}
+				Button("OK") {}
+					 .keyboardShortcut(.defaultAction)
+
 				Button(action: {}, label: {
 					Text("Weather")
 					Image(systemName: "cloud.sun.rain")
 				})
-				.buttonStyle(DefaultButtonStyle())
 			}
 			
 		}

--- a/App/Pages/HIColorsView.swift
+++ b/App/Pages/HIColorsView.swift
@@ -8,25 +8,6 @@
 import SwiftUI
 import UIKit
 
-struct HIColorWell: View, UIViewRepresentable {
-	typealias UIViewType = UIColorWell
-	let view = UIColorWell()
-	var action:(_ color:UIColor?) -> Void = { color in }
-	
-	func makeUIView(context: Context) -> UIViewType {
-		view.selectedColor = .red
-		return view
-	}
-	
-	func updateUIView(_ uiView: UIViewType, context: Context) {
-		
-		view.addAction(UIAction(handler: { _ in
-			self.action(view.selectedColor)
-		}), for: .valueChanged)
-	}
-}
-
-
 struct HIColorsView: View {
 	@State var a = Color.red
 	
@@ -36,13 +17,9 @@ struct HIColorsView: View {
 				.bold()
 			
 			HStack {
-				HIColorWell(action: { color in
-					guard let color = color else { return }
-					
-					a = Color(color)
-				})
+				ColorPicker(selection: $a) {}
 				.frame(width: UIFloat(40), height: UIFloat(40))
-				
+
 				Text("Colored label")
 					.foregroundColor(a)
 			}

--- a/App/Pages/HIPickersView.swift
+++ b/App/Pages/HIPickersView.swift
@@ -9,22 +9,6 @@ import SwiftUI
 import UIKit
 
 
-struct HIDateTimePicker: View, UIViewRepresentable {
-	typealias UIViewType = UIDatePicker
-	let view = UIDatePicker()
-	var mode = UIDatePicker.Mode.dateAndTime
-	
-	func makeUIView(context: Context) -> UIViewType {
-		view.locale = NSLocale(localeIdentifier: "en_GB") as Locale
-		view.timeZone = TimeZone(identifier: "UTC")
-		return view
-	}
-	
-	func updateUIView(_ uiView: UIViewType, context: Context) {
-		view.datePickerMode = mode
-	}
-}
-
 struct HIPickersView: View {
 	@State var a = Date()
 	
@@ -33,11 +17,7 @@ struct HIPickersView: View {
 			Text("Date & Time Pickers")
 				.bold()
 			
-			HStack {
-				Text("Starts:")
-				HIDateTimePicker(mode:.date)
-				HIDateTimePicker(mode:.time)
-			}
+			DatePicker("Starts:", selection: $a)
 		}
 		.padding()
 	}

--- a/App/Pages/HIProgressIndicatorView.swift
+++ b/App/Pages/HIProgressIndicatorView.swift
@@ -7,20 +7,6 @@
 
 import SwiftUI
 
-struct HIProgressView: View, UIViewRepresentable {
-	typealias UIViewType = UIProgressView
-	let view = UIProgressView()
-	var value = Float(0)
-	
-	func makeUIView(context: Context) -> UIViewType {
-		return view
-	}
-	
-	func updateUIView(_ uiView: UIViewType, context: Context) {
-		view.progress = value
-	}
-}
-
 struct HIActivityIndicatorView: View, UIViewRepresentable {
 	typealias UIViewType = UIActivityIndicatorView
 	let view = UIActivityIndicatorView()
@@ -48,10 +34,10 @@ struct HIProgressIndicatorView: View {
 		VStack(alignment:.leading) {
 			Text("Progress Views")
 				.bold()
-			
-			HIProgressView(value: 0.5)
+
+			ProgressView(value: 0.5)
+			ProgressView()
 			HIActivityIndicatorView()
-			HIActivityIndicatorView(active: true)
 		}
 		.padding()
 	}

--- a/App/Pages/HITextFieldsView.swift
+++ b/App/Pages/HITextFieldsView.swift
@@ -9,18 +9,16 @@ import SwiftUI
 
 struct HIBorderedTextFieldView: View, UIViewRepresentable {
 	typealias UIViewType = UITextField
-	let view = UITextField()
-	
+
 	var placeholder = ""
-	var borderStyle = UITextField.BorderStyle.none
-	
 	func makeUIView(context: Context) -> UIViewType {
+		let view = UITextField()
+		view.borderStyle = .bezel
 		return view
 	}
 	
-	func updateUIView(_ uiView: UIViewType, context: Context) {
+	func updateUIView(_ view: UIViewType, context: Context) {
 		view.placeholder = placeholder
-		view.borderStyle = borderStyle
 	}
 }
 
@@ -50,8 +48,9 @@ struct HITextFieldsView: View {
 				.bold()
 			
 			HStack {
-				HIBorderedTextFieldView(placeholder:"Type here…", borderStyle: .bezel)
-				HIBorderedTextFieldView(placeholder:"Type here…", borderStyle: .roundedRect)
+				HIBorderedTextFieldView(placeholder: "Type here…")
+				TextField("Type here…", text: $a)
+					.textFieldStyle(RoundedBorderTextFieldStyle())
 				HISearchFieldView(placeholder:"Search…")
 			}
 		}


### PR DESCRIPTION
See commit messages for details.

This PR does not remove `HIActivityIndicatorView` because there is currently no way to produce a non-spinning activity indicator from SwiftUI. I’m not sure this is a good UI practice so perhaps that part of the gallery should be removed entirely?