### PR TITLE
Updates to  UIViewRepresentable views

### DIFF
--- a/App/Buttons/HIButtonsView.swift
+++ b/App/Buttons/HIButtonsView.swift
@@ -7,23 +7,22 @@
 
 import SwiftUI
 
-struct HIDefaultButton: View, UIViewRepresentable {
-	typealias UIViewType = UIButton
-	let view = UIButton(type:.system)
-	var title = ""
-	var action = {}
-	
-	func makeUIView(context: Context) -> UIViewType {
+struct HIDefaultButton: UIViewRepresentable {
+	let title: String
+	let action: () -> Void
+
+	private static let actionID = UIAction.Identifier(UUID().uuidString)
+
+	func makeUIView(context: Context) -> UIButton {
+		let view = UIButton(type:.system)
 		view.role = .primary
 		return view
 	}
 	
-	func updateUIView(_ uiView: UIViewType, context: Context) {
+	func updateUIView(_ view: UIViewType, context: Context) {
 		view.setTitle(title, for: .normal)
-		view.addAction(UIAction(handler: { _ in
-			self.action()
-		}), for: .touchUpInside)
-		
+		view.removeAction(identifiedBy: Self.actionID, for: .primaryActionTriggered)
+		view.addAction(UIAction(identifier: Self.actionID) { _ in action() }, for: .primaryActionTriggered)
 		view.setContentHuggingPriority(.required, for: .horizontal) // << here !!
 		view.setContentHuggingPriority(.required, for: .vertical)
 	}

--- a/App/Buttons/HISwitchesView.swift
+++ b/App/Buttons/HISwitchesView.swift
@@ -7,18 +7,22 @@
 
 import SwiftUI
 
-struct HISwitchView: View, UIViewRepresentable {
-	typealias UIViewType = UISwitch
-	let view = UISwitch()
-	var value = false
-	
-	func makeUIView(context: Context) -> UIViewType {
+struct HISwitchView: UIViewRepresentable {
+	var isOn: Binding<Bool>
+
+	func makeUIView(context: Context) -> UISwitch {
+		let view = UISwitch()
 		view.preferredStyle = .sliding
+		view.addAction(UIAction { [weak view] _ in
+			guard let view = view else { return }
+			isOn.wrappedValue = view.isOn
+			view.setOn(isOn.wrappedValue, animated: true)
+		}, for: .primaryActionTriggered)
 		return view
 	}
-	
-	func updateUIView(_ uiView: UIViewType, context: Context) {
-		view.isOn = value
+
+	func updateUIView(_ view: UISwitch, context: Context) {
+		view.setOn(isOn.wrappedValue, animated: true)
 	}
 }
 
@@ -35,11 +39,15 @@ struct HISwitchesView: View {
 			VStack(alignment:.leading) {
 				HStack {
 					Text("One")
-					HISwitchView(value: a)
+					HISwitchView(isOn: $a)
 				}
 				HStack {
 					Text("Two")
-					HISwitchView(value: b)
+					HISwitchView(isOn: $b)
+				}
+				HStack {
+					Text("Always On")
+					HISwitchView(isOn: .constant(true))
 				}
 			}
 			

--- a/App/Controls/HIColorsView.swift
+++ b/App/Controls/HIColorsView.swift
@@ -8,21 +8,22 @@
 import SwiftUI
 import UIKit
 
-struct HIColorWell: View, UIViewRepresentable {
-	typealias UIViewType = UIColorWell
-	let view = UIColorWell()
-	var action:(_ color:UIColor?) -> Void = { color in }
-	
-	func makeUIView(context: Context) -> UIViewType {
+struct HIColorWell: UIViewRepresentable {
+	let action: (_ color:UIColor?) -> Void
+
+	private static let actionID = UIAction.Identifier(UUID().uuidString)
+
+	func makeUIView(context: Context) -> UIColorWell {
+		let view = UIColorWell()
 		view.selectedColor = .red
 		return view
 	}
-	
-	func updateUIView(_ uiView: UIViewType, context: Context) {
-		
-		view.addAction(UIAction(handler: { _ in
+
+	func updateUIView(_ view: UIColorWell, context: Context) {
+		view.removeAction(identifiedBy: Self.actionID, for: .valueChanged)
+		view.addAction(UIAction(identifier: Self.actionID) { _ in
 			self.action(view.selectedColor)
-		}), for: .valueChanged)
+		}, for: .valueChanged)
 	}
 }
 

--- a/App/Controls/HIPickersView.swift
+++ b/App/Controls/HIPickersView.swift
@@ -8,20 +8,25 @@
 import SwiftUI
 import UIKit
 
+struct HIDateTimePicker: UIViewRepresentable {
+	let mode: UIDatePicker.Mode
+	let date: Binding<Date>
 
-struct HIDateTimePicker: View, UIViewRepresentable {
-	typealias UIViewType = UIDatePicker
-	let view = UIDatePicker()
-	var mode = UIDatePicker.Mode.dateAndTime
-	
-	func makeUIView(context: Context) -> UIViewType {
+	func makeUIView(context: Context) -> UIDatePicker {
+		let view = UIDatePicker()
 		view.locale = NSLocale(localeIdentifier: "en_GB") as Locale
 		view.timeZone = TimeZone(identifier: "UTC")
+		view.addAction(UIAction { [weak view] _ in
+			guard let view = view else { return }
+			date.wrappedValue = view.date
+			view.setDate(date.wrappedValue, animated: true)
+		}, for: .valueChanged)
 		return view
 	}
-	
-	func updateUIView(_ uiView: UIViewType, context: Context) {
+
+	func updateUIView(_ view: UIDatePicker, context: Context) {
 		view.datePickerMode = mode
+		view.setDate(date.wrappedValue, animated: true)
 	}
 }
 
@@ -35,8 +40,8 @@ struct HIPickersView: View {
 			
 			HStack {
 				Text("Starts:")
-				HIDateTimePicker(mode:.date)
-				HIDateTimePicker(mode:.time)
+				HIDateTimePicker(mode:.date, date: $a)
+				HIDateTimePicker(mode:.time, date: $a)
 			}
 		}
 		.padding()

--- a/App/Controls/HIProgressIndicatorView.swift
+++ b/App/Controls/HIProgressIndicatorView.swift
@@ -7,31 +7,28 @@
 
 import SwiftUI
 
-struct HIProgressView: View, UIViewRepresentable {
-	typealias UIViewType = UIProgressView
-	let view = UIProgressView()
-	var value = Float(0)
+struct HIProgressView: UIViewRepresentable {
+	let value: Float
 	
-	func makeUIView(context: Context) -> UIViewType {
-		return view
+	func makeUIView(context: Context) -> UIProgressView {
+		UIProgressView()
 	}
 	
-	func updateUIView(_ uiView: UIViewType, context: Context) {
+	func updateUIView(_ view: UIProgressView, context: Context) {
 		view.progress = value
 	}
 }
 
-struct HIActivityIndicatorView: View, UIViewRepresentable {
-	typealias UIViewType = UIActivityIndicatorView
-	let view = UIActivityIndicatorView()
-	var active = false
-	
-	func makeUIView(context: Context) -> UIViewType {
+struct HIActivityIndicatorView: UIViewRepresentable {
+	let active: Bool
+
+	func makeUIView(context: Context) -> UIActivityIndicatorView {
+		let view = UIActivityIndicatorView()
 		view.hidesWhenStopped = false
 		return view
 	}
 	
-	func updateUIView(_ uiView: UIViewType, context: Context) {
+	func updateUIView(_ view: UIActivityIndicatorView, context: Context) {
 		if active == true {
 			view.startAnimating()
 		}
@@ -48,9 +45,9 @@ struct HIProgressIndicatorView: View {
 		VStack(alignment:.leading) {
 			Text("Progress Views")
 				.bold()
-			
+
 			HIProgressView(value: 0.5)
-			HIActivityIndicatorView()
+			HIActivityIndicatorView(active: false)
 			HIActivityIndicatorView(active: true)
 		}
 		.padding()

--- a/App/Text/HITextFieldsView.swift
+++ b/App/Text/HITextFieldsView.swift
@@ -7,37 +7,30 @@
 
 import SwiftUI
 
-struct HIBorderedTextFieldView: View, UIViewRepresentable {
-	typealias UIViewType = UITextField
-	let view = UITextField()
-	
-	var placeholder = ""
-	var borderStyle = UITextField.BorderStyle.none
-	
-	func makeUIView(context: Context) -> UIViewType {
-		return view
+struct HIBorderedTextFieldView: UIViewRepresentable {
+	let placeholder: String
+	let borderStyle: UITextField.BorderStyle
+
+	func makeUIView(context: Context) -> UITextField {
+		UITextField()
 	}
 	
-	func updateUIView(_ uiView: UIViewType, context: Context) {
+	func updateUIView(_ view: UITextField, context: Context) {
 		view.placeholder = placeholder
 		view.borderStyle = borderStyle
 	}
 }
 
-struct HISearchFieldView: View, UIViewRepresentable {
-	typealias UIViewType = UISearchTextField
-	let view = UISearchTextField()
-	
-	var placeholder = ""
-	var borderStyle = UITextField.BorderStyle.roundedRect
-	
-	func makeUIView(context: Context) -> UIViewType {
-		return view
+struct HISearchFieldView: UIViewRepresentable {
+	let placeholder: String
+
+	func makeUIView(context: Context) -> UISearchTextField {
+		return UISearchTextField()
 	}
 	
-	func updateUIView(_ uiView: UIViewType, context: Context) {
+	func updateUIView(_ view: UISearchTextField, context: Context) {
 		view.placeholder = placeholder
-		view.borderStyle = borderStyle
+		view.borderStyle = .roundedRect
 	}
 }
 


### PR DESCRIPTION
This PR:
- removes the redundant `View` conformance
- converts `var` properties to `let` to communicate the single-use immutable nature of representable struct instances
- update views that use actions to clean up the action before re-adding it
- avoid re-creating the `UIView` on each update
- for Binding-bound views, update the value of the view when the value changes to ensure custom binding behavior is preserved